### PR TITLE
Fixed issue with a redundant .raw

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.3
+
+- Added null-saftey
+
 ## 1.0.2
 
 - Package related fixes

--- a/lib/src/color_convert_base.dart
+++ b/lib/src/color_convert_base.dart
@@ -167,9 +167,9 @@ class _ConvertRouteReceiver {
     }
     if (_isValidColorSpace(from) && _isValidColorSpace(to_)) {
       var result = _convert(from, to_, arg);
-      if (isRaw && result is _ConversionResult) {
+      if (isRaw) {
         to = '';
-        return result.raw;
+        if (result is _ConversionResult) return result.raw;
       }
       return result;
     }

--- a/lib/src/color_convert_base.dart
+++ b/lib/src/color_convert_base.dart
@@ -3,8 +3,8 @@ import 'dart:core';
 
 import 'routes.dart';
 
-List<String> _getRoute(List<String> path, String current, String to) {
-  for (final kv in conversionRoutes[current].entries) {
+List<String?> _getRoute(List<String?> path, String current, String? to) {
+  for (final kv in conversionRoutes[current]!.entries) {
     final key = kv.key;
     if (path.contains(key)) {
       continue;
@@ -13,7 +13,7 @@ List<String> _getRoute(List<String> path, String current, String to) {
       path.add(current);
     }
     path.add(key);
-    if (conversionRoutes[key].containsKey(to)) {
+    if (conversionRoutes[key]!.containsKey(to)) {
       path.add(to);
       return path;
     } else {
@@ -26,28 +26,28 @@ List<String> _getRoute(List<String> path, String current, String to) {
   return path;
 }
 
-dynamic _convert(String from, String to, dynamic value) {
+dynamic _convert(String from, String? to, dynamic value) {
   dynamic result;
 
-  if (conversionRoutes[from].containsKey(to)) {
-    result = (conversionRoutes[from][to](value));
+  if (conversionRoutes[from]!.containsKey(to)) {
+    result = (conversionRoutes[from]![to!](value));
   } else {
     var path = _getRoute([], from, to);
-    var currentFrom = from;
+    String? currentFrom = from;
     result = value;
     for (var currentTo in path) {
-      result = conversionRoutes[currentFrom][currentTo](result);
+      result = conversionRoutes[currentFrom!]![currentTo!](result);
       currentFrom = currentTo;
     }
   }
 
   if (result is List) {
-    return _ConversionResult(result);
+    return _ConversionResult(result as List<num>);
   }
   return result;
 }
 
-bool _isValidColorSpace(String name) => colorSpaceNames.contains(name);
+bool _isValidColorSpace(String? name) => colorSpaceNames.contains(name);
 
 class _ConversionResult extends Object with ListMixin<int> {
   final List<num> _list = [];
@@ -134,13 +134,13 @@ const symbolToString = {
   Symbol('channels'): 'channels',
 };
 
-String getMemberName(Symbol symbol) {
+String? getMemberName(Symbol symbol) {
   return symbolToString[symbol];
 }
 
 class _ConvertRouteReceiver {
   String from = '';
-  String to = '';
+  String? to = '';
 
   @override
   dynamic noSuchMethod(Invocation msg) {

--- a/lib/src/hwb.dart
+++ b/lib/src/hwb.dart
@@ -37,7 +37,7 @@ List<num> rgb(ListBase<num> hwb) {
 
   final n = wh + f * (v - wh); // Linear interpolation
 
-  double r, g, b;
+  double r = 0, g = 0, b = 0;
 
   if (i == 6 || i == 0) {
     r = v;

--- a/lib/src/misc_color_spaces.dart
+++ b/lib/src/misc_color_spaces.dart
@@ -9,14 +9,14 @@ List<num> lch2lab(ListBase<num> lch) {
   final h = lch[2];
 
   final hr = h / 360 * 2 * PI;
-  final a = c * cos(hr);
-  final b = c * sin(hr);
+  final num a = c * cos(hr);
+  final num b = c * sin(hr);
 
   return [l, a, b];
 }
 
 List<num> hex2rgb(dynamic hex) {
-  int integer;
+  late int integer;
 
   if (hex is String) {
     if (hex.length == 3) {
@@ -44,8 +44,8 @@ List<num> ansi162rgb(num args) {
 
   final mult = ((args > 50 ? 1 : 0) + 1) * 0.5;
   final r = (((color as int) & 1) * mult) * 255;
-  final g = ((((color as int) >> 1) & 1) * mult) * 255;
-  final b = ((((color as int) >> 2) & 1) * mult) * 255;
+  final g = (((color >> 1) & 1) * mult) * 255;
+  final b = (((color >> 2) & 1) * mult) * 255;
 
   return [r, g, b];
 }

--- a/lib/src/rgb.dart
+++ b/lib/src/rgb.dart
@@ -20,7 +20,7 @@ List<num> hsl(ListBase<num> rgb) {
   final min_ = min(min(r, g), b);
   final max_ = max(max(r, g), b);
   final delta = max_ - min_;
-  double h, s;
+  double h = 0, s = 0;
 
   if (max_ == min_) {
     h = 0;
@@ -52,7 +52,7 @@ List<num> hsl(ListBase<num> rgb) {
 }
 
 List<num> hsv(ListBase<num> rgb) {
-  double rdif, gdif, bdif, h, s;
+  double rdif, gdif, bdif, h = 0, s;
 
   final r = rgb[0] / 255;
   final g = rgb[1] / 255;
@@ -94,7 +94,7 @@ List<num> hwb(List<num> rgb) {
   final r = rgb[0];
   final g = rgb[1];
   var b = rgb[2].toDouble();
-  final h = hsl(rgb)[0];
+  final h = hsl(rgb as ListBase<num>)[0];
   final w = 1 / 255 * min(r, min(g, b));
   b = 1 - 1 / 255 * max(r, max(g, b));
   return [h, w * 100, b * 100];
@@ -118,19 +118,19 @@ List<num> cmyk(List<num> rgb) {
   ];
 }
 
-String keyword(ListBase<num> rgb) {
+String? keyword(ListBase<num> rgb) {
   if (reverseKeywords.containsValue(rgb)) {
     return reverseKeywords[rgb];
   }
 
   var currentClosestDistance = double.infinity;
-  String currentClosestKeyword;
+  String? currentClosestKeyword;
 
   for (final keyword in cssKeywords.keys) {
-    var value = cssKeywords[keyword];
+    var value = cssKeywords[keyword]!;
 
     // Compute comparative distance
-    final distance = _comparativeDistance(rgb, value);
+    final distance = _comparativeDistance(rgb, value as ListBase<num>);
 
     // Check if its less, if so set as closest
     if (distance < currentClosestDistance) {
@@ -148,9 +148,9 @@ List<num> xyz(List<num> rgb) {
   var b = rgb[2] / 255.0;
 
   // Assume sRGB
-  r = r > 0.04045 ? pow((r + 0.055) / 1.055, 2.4) : (r / 12.92);
-  g = g > 0.04045 ? pow((g + 0.055) / 1.055, 2.4) : (g / 12.92);
-  b = b > 0.04045 ? pow((b + 0.055) / 1.055, 2.4) : (b / 12.92);
+  r = r > 0.04045 ? pow((r + 0.055) / 1.055, 2.4) as double : (r / 12.92);
+  g = g > 0.04045 ? pow((g + 0.055) / 1.055, 2.4) as double : (g / 12.92);
+  b = b > 0.04045 ? pow((b + 0.055) / 1.055, 2.4) as double : (b / 12.92);
 
   final x = (r * 0.4124564) + (g * 0.3575761) + (b * 0.1804375);
   final y = (r * 0.2126729) + (g * 0.7151522) + (b * 0.072175);
@@ -169,9 +169,9 @@ List<num> lab(List<num> rgb) {
   y /= 100;
   z /= 108.883;
 
-  x = x > 0.008856 ? pow(x, (1 / 3)) : (7.787 * x) + (16 / 116);
-  y = y > 0.008856 ? pow(y, (1 / 3)) : (7.787 * y) + (16 / 116);
-  z = z > 0.008856 ? pow(z, (1 / 3)) : (7.787 * z) + (16 / 116);
+  x = x > 0.008856 ? pow(x, (1 / 3)) as double : (7.787 * x) + (16 / 116);
+  y = y > 0.008856 ? pow(y, (1 / 3)) as double : (7.787 * y) + (16 / 116);
+  z = z > 0.008856 ? pow(z, (1 / 3)) as double : (7.787 * z) + (16 / 116);
 
   final l = (116 * y) - 16;
   final a = 500 * (x - y);
@@ -180,12 +180,13 @@ List<num> lab(List<num> rgb) {
   return [l, a, b];
 }
 
-int ansi16(List<num> rgb, {int saturation}) {
+int ansi16(List<num> rgb, {int? saturation}) {
   final r = rgb[0];
   final g = rgb[1];
   final b = rgb[2];
 
-  var value = saturation ?? hsv(rgb)[2]; // Hsv -> ansi16 optimization
+  var value =
+      saturation ?? hsv(rgb as ListBase<num>)[2]; // Hsv -> ansi16 optimization
 
   value = (value / 50).round();
 

--- a/lib/src/routes.dart
+++ b/lib/src/routes.dart
@@ -43,7 +43,7 @@ Map<String, Map<String, dynamic>> conversionRoutes = {
     'keyword': rgb.keyword,
     'xyz': rgb.xyz,
     'lab': rgb.lab,
-    'lch': (x) => lab.lch(rgb.lab(x)),
+    'lch': (x) => lab.lch(rgb.lab(x) as ListBase<num>),
     'ansi16': rgb.ansi16,
     'ansi256': rgb.ansi256,
     'hex': rgb.hex,
@@ -75,7 +75,7 @@ Map<String, Map<String, dynamic>> conversionRoutes = {
   'xyz': {
     'rgb': xyz.rgb,
     'lab': xyz.lab,
-    'lch': (x) => lab.lch(xyz.lab(x)),
+    'lch': (x) => lab.lch(xyz.lab(x) as ListBase<num>),
   },
   'lab': {
     'xyz': lab.xyz,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,8 +5,8 @@ repository: https://github.com/crystalboxes/color_convert
 homepage: https://github.com/crystalboxes/color_convert
 
 environment:
-  sdk: '>=2.8.1 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 
 dev_dependencies:
-  pedantic: ^1.9.0
-  test: ^1.14.4
+  pedantic: ^1.11.1
+  test: ^1.17.11


### PR DESCRIPTION
An issue occurs when a `.raw` was used with a string-return value. The issue would not reset the 'to' value causing everything to convert to its beginning.

Minimum reproducible code:

>  print(convert.rgb.hex.raw(0, 0, 0));
  print(convert.hsl.rgb([51, 22, 35]));

The second line of the above code would return the result in the format of the first line due to it having the `.raw`. In this case `6D6746` instead of its rgb value of `[109, 103, 70]`

The following changes cause the `to` to be reset, disregardless of the result type.
